### PR TITLE
Use full url in download_url key

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ INSTALLED_APPS = (
 ```
 
 You'll also need to add `rest_framework` and `django_filters`.
-Since `neurobank` uses `django-sendfile` to efficiently serve large files, you will need to set `settings.SENDFILE_BACKEND` and possibly other keys, depending on which reverse proxy you are using. Consult [the documentation for django-sendfile](https://github.com/johnsensible/django-sendfile/blob/master/README.rst) for details.
+Since `neurobank` uses `django-sendfile2` to efficiently serve large files, you will need to set `settings.SENDFILE_BACKEND` and possibly other keys, depending on which reverse proxy you are using. Consult [the documentation for django-sendfile2](https://django-sendfile2.readthedocs.io/en/latest/backends.html) for details.
 
 3. Include the neurobank URLconf in your project urls.py like this::
 

--- a/nbank_registry/models.py
+++ b/nbank_registry/models.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from django.contrib.postgres.fields import JSONField
 from django.db import models
-import nbank
 
 from nbank_registry.tools import random_id
 from nbank_registry import errors
@@ -84,6 +83,7 @@ class Location(models.Model):
 
     @staticmethod
     def _resolve_neurobank_path(location):
+        import nbank
         from nbank_registry.serializers import LocationSerializer
         serialized_location = LocationSerializer(location).data
         path_without_ext = nbank.core.get_archive(serialized_location)

--- a/nbank_registry/serializers.py
+++ b/nbank_registry/serializers.py
@@ -40,7 +40,8 @@ class ResourceSerializer(serializers.ModelSerializer):
     def get_download_url(self, obj):
         try:
             obj.resolve_to_path()
-            return reverse('neurobank:resource-download', args=[obj])
+            path = reverse('neurobank:resource-download', args=[obj])
+            return self.context['request'].build_absolute_uri(path)
         except errors.NotAvailableForDownloadError:
             return None
 

--- a/nbank_registry/tests.py
+++ b/nbank_registry/tests.py
@@ -589,7 +589,9 @@ class DownloadTests(APIAuthTestCase):
     def test_model_view_has_correct_url(self):
         url = reverse('neurobank:resource', args=[self.resource])
         response = self.client.get(url)
+        path = reverse('neurobank:resource-download', args=[self.resource])
+        download_url = 'http://testserver' + path
         self.assertEqual(
                 response.data['download_url'],
-                reverse('neurobank:resource-download', args=[self.resource])
+                download_url
         )


### PR DESCRIPTION
I forgot that `reverse` just returns the path, without including the domain name, so I wasn't testing for what I thought I was. Should be fixed now. We might encounter some difficulty because we're using a reverse proxy, but [it should be easy to fix](https://stackoverflow.com/a/58044808).

I also fixed a reference to an older, unsupported version of the sendfile library in the README 